### PR TITLE
fix

### DIFF
--- a/src/app/(frontend)/_components/Footer.tsx
+++ b/src/app/(frontend)/_components/Footer.tsx
@@ -52,37 +52,37 @@ export default function Footer({ small }: { small?: boolean }) {
 
         <div className="flex flex-col sm:flex-row justify-between items-center gap-4 w-full">
           <p className="text-xs md:text-sm text-slate-gray">
-            ©️ 2025 All Rights Reserved
+            ©️ All Rights Reserved By {APP_NAME}
           </p>
-          <div className="flex flex-col sm:flex-row items-center gap-2 sm:gap-4 md:gap-6 lg:gap-8 xl:gap-12 2xl:gap-14 3xl:gap-16">
-            <div
-              className="text-xs md:text-sm text-slate-gray"
-              // className="text-xs md:text-sm text-slate-gray hover:text-white hover:underline transition"
-              // href=""
-              // target="_blank"
-              // rel="noopener noreferrer"
-            >
-              Privacy Policy
-            </div>
-            <div
-              className="text-xs md:text-sm text-slate-gray"
-              // className="text-xs md:text-sm text-slate-gray hover:text-white hover:underline transition"
-              // href=""
-              // target="_blank"
-              // rel="noopener noreferrer"
-            >
-              Terms & Condition
-            </div>
-            <div
-              className="text-xs md:text-sm text-slate-gray"
-              // className="text-xs md:text-sm text-slate-gray hover:text-white hover:underline transition"
-              // href=""
-              // target="_blank"
-              // rel="noopener noreferrer"
-            >
-              Security Policy
-            </div>
-          </div>
+          {/*<div className="flex flex-col sm:flex-row items-center gap-2 sm:gap-4 md:gap-6 lg:gap-8 xl:gap-12 2xl:gap-14 3xl:gap-16">*/}
+          {/*  <div*/}
+          {/*    className="text-xs md:text-sm text-slate-gray"*/}
+          {/*    // className="text-xs md:text-sm text-slate-gray hover:text-white hover:underline transition"*/}
+          {/*    // href=""*/}
+          {/*    // target="_blank"*/}
+          {/*    // rel="noopener noreferrer"*/}
+          {/*  >*/}
+          {/*    Privacy Policy*/}
+          {/*  </div>*/}
+          {/*  <div*/}
+          {/*    className="text-xs md:text-sm text-slate-gray"*/}
+          {/*    // className="text-xs md:text-sm text-slate-gray hover:text-white hover:underline transition"*/}
+          {/*    // href=""*/}
+          {/*    // target="_blank"*/}
+          {/*    // rel="noopener noreferrer"*/}
+          {/*  >*/}
+          {/*    Terms & Condition*/}
+          {/*  </div>*/}
+          {/*  <div*/}
+          {/*    className="text-xs md:text-sm text-slate-gray"*/}
+          {/*    // className="text-xs md:text-sm text-slate-gray hover:text-white hover:underline transition"*/}
+          {/*    // href=""*/}
+          {/*    // target="_blank"*/}
+          {/*    // rel="noopener noreferrer"*/}
+          {/*  >*/}
+          {/*    Security Policy*/}
+          {/*  </div>*/}
+          {/*</div>*/}
         </div>
       </div>
     </div>

--- a/src/app/(frontend)/_components/Home-Project/Fifth.tsx
+++ b/src/app/(frontend)/_components/Home-Project/Fifth.tsx
@@ -110,7 +110,10 @@ function VideoBackground({
       ("intro" === phase ? introRef : loopRef).current?.play().finally();
     } else {
       introRef.current?.pause();
+      introRef.current?.load();
       loopRef.current?.pause();
+      loopRef.current?.load();
+      setPhase("intro");
     }
     // ref.current.addEventListener('timeupdate', () => console.log('11', ref?.current?.currentTime))
   }, [isInView, introRef?.current, loopRef?.current]);
@@ -141,7 +144,7 @@ function VideoBackground({
         ref={loopRef}
         width={2560}
         height={1440}
-        autoPlay
+        autoPlay={false}
         muted
         controls={false}
         loop={true}

--- a/src/app/(frontend)/_components/Home-Project/index.tsx
+++ b/src/app/(frontend)/_components/Home-Project/index.tsx
@@ -36,6 +36,7 @@ export default function ProjectHome() {
               <div id="section3" className="section">
                 <Third />
               </div>
+              <div className="w-full h-0.25 line-ray" />
               <div id="section5" className="section">
                 <Fifth />
               </div>
@@ -96,6 +97,7 @@ export default function ProjectHome() {
           <Second />
           <div className="w-full h-0.25 line-ray" />
           <Third />
+          <div className="w-full h-0.25 line-ray" />
           <Fifth />
         </>
       )}

--- a/src/app/(frontend)/_components/Home-Sales/Fifth.tsx
+++ b/src/app/(frontend)/_components/Home-Sales/Fifth.tsx
@@ -111,7 +111,10 @@ function VideoBackground({
       ("intro" === phase ? introRef : loopRef).current?.play().finally();
     } else {
       introRef.current?.pause();
+      introRef.current?.load();
       loopRef.current?.pause();
+      loopRef.current?.load();
+      setPhase("intro");
     }
     // ref.current.addEventListener('timeupdate', () => console.log('11', ref?.current?.currentTime))
   }, [isInView, introRef?.current, loopRef?.current]);
@@ -142,7 +145,7 @@ function VideoBackground({
         ref={loopRef}
         width={2560}
         height={1440}
-        autoPlay
+        autoPlay={false}
         muted
         controls={false}
         loop={true}

--- a/src/app/(frontend)/_components/Home-Sales/Third.tsx
+++ b/src/app/(frontend)/_components/Home-Sales/Third.tsx
@@ -114,7 +114,10 @@ function VideoBackground({ isInView }: { isInView: boolean }) {
       ("intro" === phase ? introRef : loopRef).current?.play().finally();
     } else {
       introRef.current?.pause();
+      introRef.current?.load();
       loopRef.current?.pause();
+      loopRef.current?.load();
+      setPhase("intro");
     }
     // ref.current.addEventListener('timeupdate', () => console.log('11', ref?.current?.currentTime))
   }, [isInView, introRef?.current, loopRef?.current]);
@@ -144,7 +147,7 @@ function VideoBackground({ isInView }: { isInView: boolean }) {
         ref={loopRef}
         width={2560}
         height={1440}
-        autoPlay
+        autoPlay={false}
         muted
         controls={false}
         loop={true}

--- a/src/app/(frontend)/_components/Home-Sales/index.tsx
+++ b/src/app/(frontend)/_components/Home-Sales/index.tsx
@@ -37,9 +37,11 @@ export default function SalesHome() {
               <div id="section3" className="section">
                 <Third />
               </div>
+              <div className="w-full h-0.25 line-ray" />
               <div id="section4" className="section">
                 <Fourth />
               </div>
+              <div className="w-full h-0.25 line-ray" />
               <div id="section5" className="section">
                 <Fifth />
               </div>
@@ -100,7 +102,9 @@ export default function SalesHome() {
           <Second />
           <div className="w-full h-0.25 line-ray" />
           <Third />
+          <div className="w-full h-0.25 line-ray" />
           <Fourth />
+          <div className="w-full h-0.25 line-ray" />
           <Fifth />
         </>
       )}

--- a/src/app/(frontend)/_components/Map/index.tsx
+++ b/src/app/(frontend)/_components/Map/index.tsx
@@ -3,14 +3,14 @@
 import dynamic from "next/dynamic";
 import { useMemo } from "react";
 import { Countries } from "../../_mocks/map";
+import GlowingEdgeCard from "../../_components/GlowingEdgeCard";
 
 const GlobeMap = dynamic(() => import("./GlobeMap"), { ssr: false });
 
 function CountriesList() {
-  const [availableArr, waitlistArr, comingSoonArr] = useMemo(() => {
+  const [availableArr, waitlistArr, columns, rows, width] = useMemo(() => {
     const _availableArr: string[] = [];
     const _waitlistArr: string[] = [];
-    const _comingSoonArr: string[] = [];
     Countries.features.forEach((feature) => {
       switch (feature.properties.STATE) {
         case "available":
@@ -19,36 +19,79 @@ function CountriesList() {
         case "waitlist":
           _waitlistArr.push(feature.properties.ADMIN);
           break;
-        case "coming soon":
-          _comingSoonArr.push(feature.properties.ADMIN);
-          break;
       }
     });
-    return [_availableArr, _waitlistArr, _comingSoonArr];
+    const _columns =
+      _waitlistArr.length / _availableArr.length > 2
+        ? 4
+        : _waitlistArr.length / _availableArr.length > 1
+          ? 3
+          : 2;
+    const _waitlistRows = Math.ceil(_waitlistArr.length / (_columns - 1));
+    const _rows = Math.max(_availableArr.length, _waitlistRows);
+    const _waitlistArr2 = [];
+    for (let i = 0; i < _rows - 1; i++) {
+      _waitlistArr2.push(
+        _waitlistArr.slice(_waitlistRows * i, _waitlistRows * (i + 1)),
+      );
+    }
+    return [
+      _availableArr,
+      _waitlistArr2,
+      _columns,
+      _rows,
+      `${100 / _columns}%`,
+    ];
   }, []);
 
   return (
-    <div className="relative w-full max-w-260 mt-10 border-gradient-rounded line-ray rounded-xl text-base font-semibold text-white">
-      <div className="flex flex-col w-full p-4 bg-eerie-black rounded-xl">
-        <div className="flex w-full py-2 border-b-1 border-b-dark-gray">
-          <div className="p-4 w-35 flex-none">Available</div>
-          <div className="p-4">
-            <p>{availableArr.join(", ")}</p>
+    <div className="relative w-full max-w-270 mt-10 border-gradient-rounded line-ray rounded-xl text-base font-semibold text-jet-black">
+      <GlowingEdgeCard autoPlayOnHover className="w-full h-full">
+        <div className="flex flex-col w-full bg-eerie-black rounded-xl">
+          <div
+            className="py-4.5 -m-0.25 rounded-xl"
+            style={{
+              background: "linear-gradient(90deg, #00FFC2 0%, #7DDAFF 100%)",
+            }}
+          >
+            <div className="flex justify-between px-10">
+              <div className="shrink-0" style={{ width }}>
+                Available
+              </div>
+              {new Array(columns - 1).fill("").map((_, i) => (
+                <div key={i} className="shrink-0" style={{ width }}>
+                  Waitlist
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="text-white px-10">
+            {new Array(rows).fill("").map((_, i) => (
+              <div
+                key={i}
+                className="flex justify-between py-4 border-b-1 border-b-dark-gray"
+              >
+                <div className="shrink-0" style={{ width }}>
+                  {availableArr?.[i]}
+                </div>
+                <div className="shrink-0" style={{ width }}>
+                  {waitlistArr?.[0]?.[i]}
+                </div>
+                {columns >= 3 && (
+                  <div className="shrink-0" style={{ width }}>
+                    {waitlistArr?.[1]?.[i]}
+                  </div>
+                )}
+                {columns >= 4 && (
+                  <div className="shrink-0" style={{ width }}>
+                    {waitlistArr?.[2]?.[i]}
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
         </div>
-        <div className="flex w-full py-2 border-b-1 border-b-dark-gray">
-          <div className="p-4 w-35 flex-none">Waitlist</div>
-          <div className="p-4">
-            <p>{waitlistArr.join(", ")}</p>
-          </div>
-        </div>
-        <div className="flex w-full py-2">
-          <div className="p-4 w-35 flex-none">Coming soon</div>
-          <div className="p-4">
-            <p>{comingSoonArr.join(", ")}</p>
-          </div>
-        </div>
-      </div>
+      </GlowingEdgeCard>
     </div>
   );
 }

--- a/src/app/(frontend)/_components/Navbar.tsx
+++ b/src/app/(frontend)/_components/Navbar.tsx
@@ -60,14 +60,14 @@ function WindowNavChild({ route }: { route: { name: string; url: string } }) {
     return (
       <a
         href={route.url}
-        className={`text-base 3xl:text-lg 4xl:text-xl ${isActive ? "text-white" : "text-white/60"} hover:text-white hover:underline transition`}
+        className={`text-base 2xl:text-lg 3xl:text-xl ${isActive ? "text-white" : "text-white/60"} hover:text-white hover:underline transition`}
       >
         {route.name}
       </a>
     );
   } else {
     return (
-      <div className="text-base 3xl:text-lg 4xl:text-xl text-white/60">
+      <div className="text-base 2xl:text-lg 3xl:text-xl text-white/60">
         {route.name}
       </div>
     );
@@ -168,7 +168,7 @@ function MobileNav() {
 export default function Navbar() {
   return (
     <>
-      <div className="navbar fixed top-0 w-full h-12 md:h-13 lg:h-14 xl:h-15 2xl:h-18 3xl:h-20 4xl:h-22 z-40 flex justify-center bg-jet-black border-b border-dark-slate-gray">
+      <div className="navbar fixed top-0 w-full h-12 md:h-13 lg:h-14 xl:h-15 2xl:h-18 3xl:h-20 z-40 flex justify-center bg-jet-black border-b border-dark-slate-gray">
         <div className="navbar-container flex items-center justify-between w-full h-full">
           <MobileNav />
           <WindowNav />

--- a/src/app/(frontend)/_components/NavbarPlaceholder.tsx
+++ b/src/app/(frontend)/_components/NavbarPlaceholder.tsx
@@ -7,6 +7,6 @@ export default function NavbarPlaceholder() {
   return ["/", "/roadmap"].includes(pathname) ? (
     <></>
   ) : (
-    <div className="navbar-placeholder w-full h-12 md:h-13 lg:h-14 xl:h-15 2xl:h-18 3xl:h-20 4xl:h-22" />
+    <div className="navbar-placeholder w-full h-12 md:h-13 lg:h-14 xl:h-15 2xl:h-18 3xl:h-20" />
   );
 }

--- a/src/app/(frontend)/_components/News/NewsList.tsx
+++ b/src/app/(frontend)/_components/News/NewsList.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useScroll } from "ahooks";
-import { motion, useInView } from "framer-motion";
+import { motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import ReactPaginate from "react-paginate";
 import { Media, Post } from "@/payload-types";
 import NewMatrix from "../NewMatrix";
@@ -56,13 +55,11 @@ export default function NewsList({
   pageSize,
   pageIndex,
   posts,
-  lastCompleted,
 }: {
   postCount: number;
   pageSize: number;
   pageIndex: number;
   posts: Post[];
-  lastCompleted: boolean;
 }) {
   const router = useRouter();
 
@@ -71,29 +68,8 @@ export default function NewsList({
     [postCount, pageSize],
   );
 
-  const ref = useRef<HTMLDivElement>(null);
-  const isInView = useInView(ref, { once: true });
-  const scrollPosition = useScroll();
-
-  const [showContent, setShowContent] = useState(false);
-  useEffect(() => {
-    if (isInView && lastCompleted) {
-      setShowContent(true);
-    } else if (
-      ref?.current?.offsetTop &&
-      scrollPosition?.top &&
-      scrollPosition.top / ref.current.offsetTop > 0.9
-    ) {
-      setShowContent(true);
-    }
-  }, [isInView, lastCompleted, ref.current?.offsetTop, scrollPosition?.top]);
-
-  if (!showContent) {
-    return <div ref={ref} className="mt-10 h-180" />;
-  }
-
   return (
-    <div ref={ref} className="news-list flex flex-col mt-10 relative z-[2]">
+    <div className="news-list flex flex-col mt-10 relative z-[2]">
       <div className="flex flex-col gap-4">
         {posts.map((item) => (
           <motion.div

--- a/src/app/(frontend)/_components/News/TopNews.tsx
+++ b/src/app/(frontend)/_components/News/TopNews.tsx
@@ -6,13 +6,7 @@ import Link from "next/link";
 import { Category, Post, Media } from "@/payload-types";
 import NewMatrix from "../NewMatrix";
 
-export default function TopNews({
-  pinnedPosts,
-  setLastCompleted,
-}: {
-  pinnedPosts: Post[];
-  setLastCompleted: (val: boolean) => void;
-}) {
+export default function TopNews({ pinnedPosts }: { pinnedPosts: Post[] }) {
   return (
     <div className="top-news flex flex-col-reverse md:flex-row gap-4 sm:gap-6 md:gap-2 mt-4 md:mt-5 lg:mt-6 xl:mt-7 relative z-[1]">
       <div className="top-news-left md:w-[50%] flex flex-col gap-2">
@@ -24,14 +18,8 @@ export default function TopNews({
               key={item.id}
               initial={{ opacity: 0, y: 150 }}
               whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.75, delay: i * 0.3 }}
+              transition={{ duration: 0.75 }}
               viewport={{ once: true, margin: "150px" }}
-              onAnimationComplete={() => {
-                // console.log("onAnimationComplete", i, dayjs().format('mm:ss SSS'))
-                if (1 === i) {
-                  setLastCompleted(true);
-                }
-              }}
             >
               <Link
                 href={`/news/${item.id}`}

--- a/src/app/(frontend)/_components/News/index.tsx
+++ b/src/app/(frontend)/_components/News/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { Post } from "@/payload-types";
 import NewsFlash from "./NewsFlash";
 import TopNews from "./TopNews";
@@ -19,18 +18,15 @@ export default function News({
   pinnedPosts: Post[];
   remainingPosts: Post[];
 }) {
-  const [lastCompleted, setLastCompleted] = useState(false); // Is the last animation of the first screen completed?
-
   return (
     <div className="news w-full max-w-370 min-h-100 mx-auto p-4 sm:p-6 md:p-7 lg:p-8 xl:p-9 2xl:p-10 relative overflow-hidden antialiased">
       <NewsFlash />
-      <TopNews pinnedPosts={pinnedPosts} setLastCompleted={setLastCompleted} />
+      <TopNews pinnedPosts={pinnedPosts} />
       <NewsList
         postCount={postCount}
         pageSize={pageSize}
         pageIndex={pageIndex}
         posts={remainingPosts}
-        lastCompleted={lastCompleted}
       />
     </div>
   );

--- a/src/app/(frontend)/_components/WalletButton/index.tsx
+++ b/src/app/(frontend)/_components/WalletButton/index.tsx
@@ -26,7 +26,7 @@ export default function WalletButton() {
                 return (
                   <button
                     type="button"
-                    className="btn-mint-green connect-wallet w-48 3xl:w-64 4xl:w-72 h-full flex justify-center items-center gap-2 px-1.5 py-3 border border-white/10 text-sm 3xl:text-base 4xl:text-2xl text-[#051117] cursor-pointer"
+                    className="btn-mint-green connect-wallet w-48 3xl:w-64 h-full flex justify-center items-center gap-2 px-1.5 py-3 border border-white/10 text-base 2xl:text-lg 3xl:text-xl text-[#051117] cursor-pointer"
                     onClick={openConnectModal}
                   >
                     Connect Wallet
@@ -38,7 +38,7 @@ export default function WalletButton() {
                 return (
                   <button
                     type="button"
-                    className="btn-mint-green connect-wallet w-48 3xl:w-64 4xl:w-72 h-full flex justify-center items-center gap-2 px-1.5 py-3 border border-white/10 text-sm 3xl:text-base 4xl:text-2xl text-[#051117] cursor-pointer"
+                    className="btn-mint-green connect-wallet w-48 3xl:w-64 h-full flex justify-center items-center gap-2 px-1.5 py-3 border border-white/10 text-base 2xl:text-lg 3xl:text-xl text-[#051117] cursor-pointer"
                     onClick={openChainModal}
                   >
                     Wrong network
@@ -48,7 +48,7 @@ export default function WalletButton() {
 
               return (
                 <Popover className="relative h-full">
-                  <PopoverButton className="btn-mint-green connect-wallet w-48 3xl:w-64 4xl:w-72 h-full flex justify-center items-center gap-2 px-1.5 py-3 border border-white/10 text-lg 3xl:text-xl 4xl:text-2xl text-[#051117] cursor-pointer">
+                  <PopoverButton className="btn-mint-green connect-wallet w-48 3xl:w-64 h-full flex justify-center items-center gap-2 px-1.5 py-3 border border-white/10 text-base 2xl:text-lg 3xl:text-xl text-[#051117] cursor-pointer">
                     {account.displayName}
                   </PopoverButton>
                   <WalletPanel account={account} chain={chain} />
@@ -58,7 +58,7 @@ export default function WalletButton() {
               // return (
               //   <button
               //     type="button"
-              //     className="btn-mint-green connect-wallet w-48 3xl:w-64 4xl:w-72 h-full flex justify-center items-center gap-2 px-1.5 py-3 border border-white/10 text-sm 3xl:text-base 4xl:text-2xl text-[#051117] cursor-pointer"
+              //     className="btn-mint-green connect-wallet w-48 3xl:w-64 h-full flex justify-center items-center gap-2 px-1.5 py-3 border border-white/10 text-base 2xl:text-lg 3xl:text-xl text-[#051117] cursor-pointer"
               //     onClick={openAccountModal}
               //   >
               //     {account.displayName}

--- a/src/app/(frontend)/globals.scss
+++ b/src/app/(frontend)/globals.scss
@@ -98,10 +98,10 @@ input:focus-visible {
     //height: calc(100vh - 80px);
     padding-top: 80px;
   }
-  @media (width >= 150rem) {
-    //height: calc(100vh - 88px);
-    padding-top: 88px;
-  }
+  //@media (width >= 150rem) {
+  //  //height: calc(100vh - 88px);
+  //  padding-top: 88px;
+  //}
 }
 
 .text-white-gradient {

--- a/src/app/dashboard/_components/MediaDialogs/ChooseMediaDialog/index.tsx
+++ b/src/app/dashboard/_components/MediaDialogs/ChooseMediaDialog/index.tsx
@@ -9,6 +9,9 @@ import Pagination from "@/app/dashboard/_components/Pagination";
 import Button from "@/app/dashboard/_components/Button";
 import { filesize } from "filesize";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
 
 const PAGE_SIZE = 10;
 
@@ -84,7 +87,7 @@ export default function ChooseMediaDialog({
                 </th>
                 <th className="max-lg:nth-5:hidden max-lg:last:hidden">Alt</th>
                 <th className="max-lg:nth-5:hidden max-lg:last:hidden">
-                  Last edited
+                  Last edited (UTC)
                 </th>
               </tr>
             </thead>
@@ -130,7 +133,7 @@ export default function ChooseMediaDialog({
                   </td>
                   <td className="max-md:hidden">{doc.alt}</td>
                   <td className="text-t-secondary max-lg:hidden">
-                    {dayjs(doc.updatedAt).format("DD MMM, hh:mm A")}
+                    {dayjs(doc.updatedAt).utc().format("DD MMM, hh:mm A")}
                   </td>
                 </tr>
               ))}

--- a/src/app/dashboard/_templates/Categories/CategoryListPage/List/Item.tsx
+++ b/src/app/dashboard/_templates/Categories/CategoryListPage/List/Item.tsx
@@ -5,6 +5,7 @@ import Icon from "@/app/dashboard/_components/Icon";
 import DeleteItems from "@/app/dashboard/_components/DeleteItems";
 import { Category } from "@/payload-types";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import Link from "next/link";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
@@ -12,6 +13,8 @@ import TableCategoryCell from "../TableCategoryCell";
 import { ROUTES } from "@/app/dashboard/_contstants/routes";
 import { useMutation } from "@tanstack/react-query";
 import axiosInstance from "@/app/dashboard/_helpers/axios";
+
+dayjs.extend(utc);
 
 const Item = ({
   category,
@@ -55,7 +58,7 @@ const Item = ({
         mobileContent={
           <div className="flex items-center gap-2 text-t-secondary/80">
             <Icon className="!size-4 fill-t-secondary" name="clock-1" />
-            {dayjs(category.updatedAt).format("DD MMM, hh:mm A")}
+            {dayjs(category.updatedAt).utc().format("DD MMM, hh:mm A")}
           </div>
         }
       >
@@ -76,7 +79,7 @@ const Item = ({
         )}
       </td>
       <td className="text-t-secondary max-lg:hidden">
-        {dayjs(category.updatedAt).format("DD MMM, hh:mm A")}
+        {dayjs(category.updatedAt).utc().format("DD MMM, hh:mm A")}
       </td>
     </TableRow>
   );

--- a/src/app/dashboard/_templates/Categories/CategoryListPage/List/index.tsx
+++ b/src/app/dashboard/_templates/Categories/CategoryListPage/List/index.tsx
@@ -4,7 +4,7 @@ import Table from "@/app/dashboard/_components/Table";
 import { Category } from "@/payload-types";
 import Item from "./Item";
 
-const tableHead = ["Category", "Parent", "Last Edited"];
+const tableHead = ["Category", "Parent", "Last Edited (UTC)"];
 
 type ListProps = {
   categories: Category[];

--- a/src/app/dashboard/_templates/HomePage/ClaimedList/index.tsx
+++ b/src/app/dashboard/_templates/HomePage/ClaimedList/index.tsx
@@ -6,17 +6,19 @@ import TableRow from "@/app/dashboard/_components/TableRow";
 import Card from "@/app/dashboard/_components/Card";
 import { Pool } from "@/payload-types";
 import { usePoolsClaimedPurchases } from "@/subgraph";
-import { displayBalance, FACTORIES, shortenAddress } from "@/web3";
+import { displayBalance, shortenAddress } from "@/web3";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { MoonLoader } from "react-spinners";
 import Button from "@/app/dashboard/_components/Button";
 import { Chain } from "viem";
 import { ROUTES } from "@/app/dashboard/_contstants/routes";
 
+dayjs.extend(utc);
+
 const PAGE_SIZE = 10;
 
 const ClaimedList = ({ chain, pools }: { chain: Chain; pools: Pool[] }) => {
-  const factory = FACTORIES[chain.id];
   const [poolAddresses, poolsMap] = useMemo(() => {
     const _poolAddresses: string[] = [];
     const _poolsMap: Map<string, Pool> = new Map();
@@ -31,7 +33,7 @@ const ClaimedList = ({ chain, pools }: { chain: Chain; pools: Pool[] }) => {
 
   const tableHeads = useMemo(
     () => [
-      { field: "claimedAt", title: "Date", enableSort: true },
+      { field: "claimedAt", title: "Date (UTC)", enableSort: true },
       { field: "buyer__id", title: "Buyer" },
       { field: "pool__name", title: "Pool", enableSort: true },
       { field: "paymentAmount", title: "Payment" },
@@ -109,6 +111,7 @@ const ClaimedList = ({ chain, pools }: { chain: Chain; pools: Pool[] }) => {
                       >
                         {dayjs
                           .unix(Number(purchase.claimedAt))
+                          .utc()
                           .format("DD MMM, hh:mm A")}
                       </a>
                     </td>

--- a/src/app/dashboard/_templates/HomePage/Purchases/index.tsx
+++ b/src/app/dashboard/_templates/HomePage/Purchases/index.tsx
@@ -6,20 +6,21 @@ import TableRow from "@/app/dashboard/_components/TableRow";
 import Card from "@/app/dashboard/_components/Card";
 import { Pool } from "@/payload-types";
 import { usePoolsPurchases } from "@/subgraph";
-import { displayBalance, FACTORIES, shortenAddress } from "@/web3";
+import { displayBalance, shortenAddress } from "@/web3";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
+import utc from "dayjs/plugin/utc";
 import { MoonLoader } from "react-spinners";
 import Button from "@/app/dashboard/_components/Button";
 import { Chain } from "viem";
 import { ROUTES } from "@/app/dashboard/_contstants/routes";
 
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 
 const PAGE_SIZE = 10;
 
 const Purchases = ({ chain, pools }: { chain: Chain; pools: Pool[] }) => {
-  const factory = FACTORIES[chain.id];
   const [poolAddresses, poolsMap] = useMemo(() => {
     const _poolAddresses: string[] = [];
     const _poolsMap: Map<string, Pool> = new Map();
@@ -34,7 +35,7 @@ const Purchases = ({ chain, pools }: { chain: Chain; pools: Pool[] }) => {
 
   const tableHeads = useMemo(
     () => [
-      { field: "createdAt", title: "Date", enableSort: true },
+      { field: "createdAt", title: "Date (UTC)", enableSort: true },
       { field: "buyer__id", title: "Buyer" },
       { field: "pool__name", title: "Pool", enableSort: true },
       { field: "paymentAmount", title: "Payment" },
@@ -50,7 +51,7 @@ const Purchases = ({ chain, pools }: { chain: Chain; pools: Pool[] }) => {
   const { data, isFetching } = usePoolsPurchases(
     chain.id,
     poolAddresses,
-    false,
+    undefined,
     orderBy,
     orderDirection,
     PAGE_SIZE,
@@ -113,6 +114,7 @@ const Purchases = ({ chain, pools }: { chain: Chain; pools: Pool[] }) => {
                       >
                         {dayjs
                           .unix(Number(purchase.createdAt))
+                          .utc()
                           .format("DD MMM, hh:mm A")}
                       </a>
                     </td>

--- a/src/app/dashboard/_templates/Media/MediaListPage/List/Item.tsx
+++ b/src/app/dashboard/_templates/Media/MediaListPage/List/Item.tsx
@@ -6,12 +6,15 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "sonner";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import Image from "@/app/dashboard/_components/Image";
 import { filesize } from "filesize";
 import { useState } from "react";
 import { ROUTES } from "@/app/dashboard/_contstants/routes";
 import { useMutation } from "@tanstack/react-query";
 import axiosInstance from "@/app/dashboard/_helpers/axios";
+
+dayjs.extend(utc);
 
 const Item = ({
   media,
@@ -98,7 +101,7 @@ const Item = ({
       </td>
       <td className="max-md:hidden">{media.alt}</td>
       <td className="text-t-secondary max-lg:hidden">
-        {dayjs(media.updatedAt).format("DD MMM, hh:mm A")}
+        {dayjs(media.updatedAt).utc().format("DD MMM, hh:mm A")}
       </td>
     </TableRow>
   );

--- a/src/app/dashboard/_templates/Media/MediaListPage/List/index.tsx
+++ b/src/app/dashboard/_templates/Media/MediaListPage/List/index.tsx
@@ -4,7 +4,7 @@ import Table from "@/app/dashboard/_components/Table";
 import { Media } from "@/payload-types";
 import Item from "./Item";
 
-const tableHead = ["Media", "Alt", "Last Edited"];
+const tableHead = ["Media", "Alt", "Last Edited (UTC)"];
 
 type ListProps = {
   mediaArray: Media[];

--- a/src/app/dashboard/_templates/Pools/DetailsPage/ClaimedList/index.tsx
+++ b/src/app/dashboard/_templates/Pools/DetailsPage/ClaimedList/index.tsx
@@ -8,9 +8,12 @@ import { Pool } from "@/payload-types";
 import { usePoolClaimedPurchases } from "@/subgraph";
 import { displayBalance, shortenAddress } from "@/web3";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { MoonLoader } from "react-spinners";
 import Button from "@/app/dashboard/_components/Button";
 import { useChains } from "wagmi";
+
+dayjs.extend(utc);
 
 const PAGE_SIZE = 10;
 
@@ -23,7 +26,7 @@ const ClaimedList = ({ pool }: { pool: Pool }) => {
 
   const tableHeads = useMemo(
     () => [
-      { field: "claimedAt", title: "Date", enableSort: true },
+      { field: "claimedAt", title: "Date (UTC)", enableSort: true },
       { field: "buyer__id", title: "Buyer" },
       { field: "paymentAmount", title: "Payment" },
       { field: "claimedAmount", title: `Claimed` },
@@ -97,6 +100,7 @@ const ClaimedList = ({ pool }: { pool: Pool }) => {
                     >
                       {dayjs
                         .unix(Number(purchase.claimedAt))
+                        .utc()
                         .format("DD MMM, hh:mm A")}
                     </a>
                   </td>

--- a/src/app/dashboard/_templates/Pools/DetailsPage/PoolInfo/index.tsx
+++ b/src/app/dashboard/_templates/Pools/DetailsPage/PoolInfo/index.tsx
@@ -18,6 +18,9 @@ import Parameter from "../../Parameter";
 import { useChains } from "wagmi";
 import { useMemo } from "react";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
 
 const PoolInfo = ({ pool }: { pool: Pool }) => {
   const chains = useChains();
@@ -79,7 +82,10 @@ const PoolInfo = ({ pool }: { pool: Pool }) => {
         />
         <Parameter
           label="Sale Started At"
-          content={dayjs.unix(pool.saleStartedAt).format("DD MMM, hh:mm A")}
+          content={dayjs
+            .unix(pool.saleStartedAt)
+            .utc()
+            .format("DD MMM, hh:mm A [UTC]")}
         />
         <Parameter
           label="Paused Duration Sum"
@@ -89,7 +95,10 @@ const PoolInfo = ({ pool }: { pool: Pool }) => {
           label="Deployed At"
           content={
             pool.deployedAt
-              ? dayjs.unix(pool.deployedAt).format("DD MMM, hh:mm A")
+              ? dayjs
+                  .unix(pool.deployedAt)
+                  .utc()
+                  .format("DD MMM, hh:mm A [UTC]")
               : "-"
           }
         />
@@ -197,7 +206,7 @@ const PoolInfo = ({ pool }: { pool: Pool }) => {
         />
         <Parameter
           label="Created At"
-          content={dayjs(pool.createdAt).format("DD MMM, hh:mm A")}
+          content={dayjs(pool.createdAt).utc().format("DD MMM, hh:mm A [UTC]")}
         />
         {pool.createdHash ? (
           <Parameter

--- a/src/app/dashboard/_templates/Pools/DetailsPage/Purchases/index.tsx
+++ b/src/app/dashboard/_templates/Pools/DetailsPage/Purchases/index.tsx
@@ -9,11 +9,13 @@ import { usePoolPurchases } from "@/subgraph";
 import { displayBalance, shortenAddress } from "@/web3";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
+import utc from "dayjs/plugin/utc";
 import { MoonLoader } from "react-spinners";
 import Button from "@/app/dashboard/_components/Button";
 import { useChains } from "wagmi";
 
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 
 const PAGE_SIZE = 10;
 
@@ -26,7 +28,7 @@ const Purchases = ({ pool }: { pool: Pool }) => {
 
   const tableHeads = useMemo(
     () => [
-      { field: "createdAt", title: "Date", enableSort: true },
+      { field: "createdAt", title: "Date (UTC)", enableSort: true },
       { field: "buyer__id", title: "Buyer" },
       { field: "paymentAmount", title: "Payment" },
       { field: "saleAmount", title: `Sale & Reward` },
@@ -41,7 +43,7 @@ const Purchases = ({ pool }: { pool: Pool }) => {
   const { data, isFetching } = usePoolPurchases(
     pool.chainId,
     pool.address,
-    false,
+    undefined,
     orderBy,
     orderDirection,
     PAGE_SIZE,
@@ -101,6 +103,7 @@ const Purchases = ({ pool }: { pool: Pool }) => {
                     >
                       {dayjs
                         .unix(Number(purchase.createdAt))
+                        .utc()
                         .format("DD MMM, hh:mm A")}
                     </a>
                   </td>

--- a/src/app/dashboard/_templates/Pools/PoolForm/index.tsx
+++ b/src/app/dashboard/_templates/Pools/PoolForm/index.tsx
@@ -542,10 +542,10 @@ const PoolForm = () => {
                   suffix="Days"
                 />
                 <Field
-                  label="Sale Started At"
+                  label="Sale Started At (UTC)"
                   type="datetime-local"
                   {...register("saleStartedAt", {
-                    setValueAs: (v) => `${v}:00${dayjs().format("Z")}`,
+                    setValueAs: (v) => `${v}:00Z`,
                   })}
                   errorMessage={errors?.saleStartedAt?.message}
                 />

--- a/src/app/dashboard/_templates/Pools/PoolForm/index.tsx
+++ b/src/app/dashboard/_templates/Pools/PoolForm/index.tsx
@@ -608,6 +608,15 @@ const PoolForm = () => {
                         placeholder="0.1"
                         tooltip={`Decimals: ${token.decimals}`}
                         {...register(`paymentRules.${index}.minPurchase`)}
+                        onChange={(e) => {
+                          factory.paymentTokens.forEach((_, k) => {
+                            setValue(
+                              `paymentRules.${k}.minPurchase`,
+                              e.target.value,
+                              { shouldValidate: true },
+                            );
+                          });
+                        }}
                         errorMessage={
                           errors?.paymentRules?.[index]?.minPurchase?.message
                         }
@@ -617,6 +626,15 @@ const PoolForm = () => {
                         placeholder="100"
                         tooltip={`Decimals: ${token.decimals}`}
                         {...register(`paymentRules.${index}.maxPurchase`)}
+                        onChange={(e) => {
+                          factory.paymentTokens.forEach((_, k) => {
+                            setValue(
+                              `paymentRules.${k}.maxPurchase`,
+                              e.target.value,
+                              { shouldValidate: true },
+                            );
+                          });
+                        }}
                         errorMessage={
                           errors?.paymentRules?.[index]?.maxPurchase?.message
                         }

--- a/src/app/dashboard/_templates/Pools/PoolsPage/List/index.tsx
+++ b/src/app/dashboard/_templates/Pools/PoolsPage/List/index.tsx
@@ -16,6 +16,9 @@ import Jdenticon from "react-jdenticon";
 import { displayBalance } from "@/web3";
 import { useMemo } from "react";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
 
 function Item({ pool }: { pool: Pool }) {
   return (
@@ -59,7 +62,7 @@ function Item({ pool }: { pool: Pool }) {
         {displayBalance(pool.totalSold)} / {displayBalance(pool.totalSaleCap)}
       </td>
       <td className="max-lg:hidden">
-        {dayjs(pool.createdAt).format("DD MMM, hh:mm A")}
+        {dayjs(pool.createdAt).utc().format("DD MMM, hh:mm A")}
       </td>
     </TableRow>
   );
@@ -67,7 +70,7 @@ function Item({ pool }: { pool: Pool }) {
 
 const List = ({ pools }: { pools: Pool[] }) => {
   const tableHeads = useMemo(
-    () => ["Pool", "Status", "Price", `Sale Cap`, "Created At"],
+    () => ["Pool", "Status", "Price", `Sale Cap`, "Created At (UTC)"],
     [],
   );
 

--- a/src/app/dashboard/_templates/Posts/DraftsPage/Grid/Item.tsx
+++ b/src/app/dashboard/_templates/Posts/DraftsPage/Grid/Item.tsx
@@ -7,10 +7,13 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import GridPost from "@/app/dashboard/_components/GridPost";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { toast } from "sonner";
 import { ROUTES } from "@/app/dashboard/_contstants/routes";
 import { useMutation } from "@tanstack/react-query";
 import axiosInstance from "@/app/dashboard/_helpers/axios";
+
+dayjs.extend(utc);
 
 const Item = ({
   post,
@@ -75,7 +78,7 @@ const Item = ({
     >
       <div className="flex items-center gap-2 text-caption text-t-secondary/80">
         <Icon className="fill-t-secondary" name="clock" />
-        {dayjs(post.updatedAt).format("DD MMM, hh:mm A")}
+        {dayjs(post.updatedAt).utc().format("DD MMM, hh:mm A")}
       </div>
     </GridPost>
   );

--- a/src/app/dashboard/_templates/Posts/DraftsPage/List/Item.tsx
+++ b/src/app/dashboard/_templates/Posts/DraftsPage/List/Item.tsx
@@ -5,6 +5,7 @@ import Icon from "@/app/dashboard/_components/Icon";
 import DeleteItems from "@/app/dashboard/_components/DeleteItems";
 import { Post } from "@/payload-types";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import Link from "next/link";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
@@ -12,6 +13,8 @@ import { ROUTES } from "@/app/dashboard/_contstants/routes";
 import TablePostCell from "../../TablePostCell";
 import { useMutation } from "@tanstack/react-query";
 import axiosInstance from "@/app/dashboard/_helpers/axios";
+
+dayjs.extend(utc);
 
 const Item = ({
   post,
@@ -55,7 +58,7 @@ const Item = ({
         mobileContent={
           <div className="flex items-center gap-2 text-t-secondary/80">
             <Icon className="!size-4 fill-t-secondary" name="clock-1" />
-            {dayjs(post.updatedAt).format("DD MMM, hh:mm A")}
+            {dayjs(post.updatedAt).utc().format("DD MMM, hh:mm A")}
           </div>
         }
       >
@@ -92,7 +95,7 @@ const Item = ({
       {/*  </div>*/}
       {/*</td>*/}
       <td className="text-t-secondary max-lg:hidden">
-        {dayjs(post.updatedAt).format("DD MMM, hh:mm A")}
+        {dayjs(post.updatedAt).utc().format("DD MMM, hh:mm A")}
       </td>
     </TableRow>
   );

--- a/src/app/dashboard/_templates/Posts/DraftsPage/List/index.tsx
+++ b/src/app/dashboard/_templates/Posts/DraftsPage/List/index.tsx
@@ -4,7 +4,7 @@ import Table from "@/app/dashboard/_components/Table";
 import { Post } from "@/payload-types";
 import Item from "./Item";
 
-const tableHead = ["Post", "Category", "Last Edited"];
+const tableHead = ["Post", "Category", "Last Edited (UTC)"];
 
 type ListProps = {
   posts: Post[];

--- a/src/app/dashboard/_templates/Posts/ReleasedPage/List/Item.tsx
+++ b/src/app/dashboard/_templates/Posts/ReleasedPage/List/Item.tsx
@@ -12,10 +12,13 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "sonner";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { ROUTES } from "@/app/dashboard/_contstants/routes";
 import TablePostCell from "../../TablePostCell";
 import { useMutation } from "@tanstack/react-query";
 import axiosInstance from "@/app/dashboard/_helpers/axios";
+
+dayjs.extend(utc);
 
 const Item = ({
   post,
@@ -127,7 +130,7 @@ const Item = ({
       {/*  </div>*/}
       {/*</td>*/}
       <td className="text-t-secondary max-lg:hidden">
-        {dayjs(post.publishedAt).format("DD MMM, hh:mm A")}
+        {dayjs(post.publishedAt).utc().format("DD MMM, hh:mm A")}
       </td>
     </TableRow>
   );

--- a/src/app/dashboard/_templates/Posts/ReleasedPage/List/index.tsx
+++ b/src/app/dashboard/_templates/Posts/ReleasedPage/List/index.tsx
@@ -5,7 +5,7 @@ import { Post } from "@/payload-types";
 import Item from "./Item";
 
 // "Rating", "Views"
-const tableHead = ["Post", "Category", "Status", "Pin", "Published At"];
+const tableHead = ["Post", "Category", "Status", "Pin", "Published At (UTC)"];
 
 type ListProps = {
   posts: Post[];


### PR DESCRIPTION
目前的遺留問題：

銷售頁面
1，錢包連結的自動擴大 還是會變得很大
2，第三屏和第五屏的回流沒有從第一個動畫開始
3，3，4螢幕的畫面分割藍線沒有加，還有都是Our Values
4，©️ 2025 All Rights Reserved的日期需要刪掉，改成©️ All Rights Reserved By AIOS是不是比較好？
5，Privacy Policy，Terms & Condition，Security Policy需要刪​​除
6，NEWS頁面的第四個欄位載入會有些卡頓 不知是否還能優化？
7，MAP頁面的LIST日方說希望嘗試之前的版本，然後刪除Coming soon，把Waitlist的國家變成2-3列顯示
8，MAP的LIST也加上光邊和點點的特效吧 這樣更有統一感

專案頁面
1，跟銷售主頁存在一樣的問題
2，Roadmap的滑動有些奇怪，是否可以設定滑動一下就降到下一個的感覺？目前滑動小的話會卡在中間
3，白皮書封面是否需要替換成綠色星星的版本我明天跟日方確認下

後台
1，Sale Started At我看好像還是時區時間？這需要改成UTC0點
2，Min Purchase和Max Purchase的輸入連動似乎還沒生效