### PR TITLE
V1.dev zenas

### DIFF
--- a/src/app/(frontend)/_components/Footer.tsx
+++ b/src/app/(frontend)/_components/Footer.tsx
@@ -26,7 +26,7 @@ export default function Footer({ small }: { small?: boolean }) {
               Decentralized AI Infrastructure for Global Scale
             </p>
           </div>
-          <div className="flex items-center gap-6">
+          <div className="flex items-center gap-6 invisible">
             <a className="" href="" target="_blank" rel="noopener noreferrer">
               <Image
                 src="/images/icon-twitter.svg"

--- a/src/app/(frontend)/_components/Home-Project/Fifth.tsx
+++ b/src/app/(frontend)/_components/Home-Project/Fifth.tsx
@@ -67,7 +67,7 @@ function Marquee({
 
   return (
     <div
-      className="relative w-full max-w-180 overflow-hidden"
+      className="relative w-full overflow-hidden"
       onMouseEnter={() => setPaused(true)}
       onMouseLeave={() => setPaused(false)}
     >
@@ -90,6 +90,7 @@ function Marquee({
           ))}
         </ul>
       </div>
+      <div className="absolute inset-0 bg-[linear-gradient(90deg,#000_0%,rgba(0,0,0,0)_20%,rgba(0,0,0,0)_80%,#000_100%)]" />
     </div>
   );
 }
@@ -194,7 +195,7 @@ export default function Fifth() {
                 }}
               />
 
-              <div className="absolute top-[50%] left-[50%] transform-[translate(-50%,-50%)]">
+              <div className="absolute top-[50%] left-[50%] w-[80%] transform-[translate(-50%,-50%)]">
                 <Marquee speed={0.05} direction="left" started={videoEnded} />
               </div>
             </GlowingEdgeCard>

--- a/src/app/(frontend)/_components/Home-Project/First.tsx
+++ b/src/app/(frontend)/_components/Home-Project/First.tsx
@@ -100,7 +100,7 @@ export default function First() {
                 to BSC — with AI managing contracts, transfers, and security,
                 all while you retain full control.
               </div>
-              <div className="flex items-center gap-7.5">
+              <div className="flex items-center gap-7.5 invisible">
                 <a
                   className=""
                   href=""

--- a/src/app/(frontend)/_components/Home-Project/Third.tsx
+++ b/src/app/(frontend)/_components/Home-Project/Third.tsx
@@ -148,7 +148,7 @@ export default function Third() {
       ref={ref}
       className="home-section page-third w-full h-screen-custom flex flex-col justify-center items-center relative overflow-hidden z-[3]"
     >
-      <div className="page-third-container w-full flex flex-auto flex-col justify-between items-center relative">
+      <div className="page-third-container w-full flex flex-auto flex-col justify-between items-center relative px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12 2xl:px-0">
         <div />
         <div className="w-full flex flex-col justify-start items-center gap-12 md:gap-14 lg:gap-16 xl:gap-18 2xl:gap-20 3xl:gap-22 relative z-[1]">
           <div className="px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12 2xl:px-0">
@@ -177,19 +177,12 @@ export default function Third() {
           <div className="w-full">
             <Marquee speed={0.05} direction="left" isInView={isInView} />
           </div>
-          <div className="flex items-center justify-between gap-2 sm:gap-2.5 md:gap-3 lg:gap-3.5 xl:gap-4 px-4 sm:px-6 lg:px-8 xl:px-10 2xl:px-14 3xl:px-16 py-4 md:py-5 lg:py-6 xl:py-7 border-b-[0.6px] border-[#9f9f9f]">
+          <div className="flex justify-center px-4 sm:px-6 lg:px-8 xl:px-10 2xl:px-14 3xl:px-16 py-4 md:py-5 lg:py-6 xl:py-7 border-b-[0.6px] border-[#9f9f9f]">
             <p className="text-xs md:text-sm xl:text-base font-semibold text-white">
               By uniting adaptive AI with resilient decentralized
               infrastructure, we deliver smarter, faster, and truly sovereign
               experiences — built to empower human potential worldwide.
             </p>
-            <Image
-              src="/images/icon-benefit-increase.svg"
-              alt=""
-              width={20}
-              height={20}
-              className="size-4 lg:size-5"
-            />
           </div>
         </div>
       </div>

--- a/src/app/(frontend)/_components/Home-Sales/First.tsx
+++ b/src/app/(frontend)/_components/Home-Sales/First.tsx
@@ -102,7 +102,7 @@ export default function First() {
                   Solana to BSC — with AI managing contracts, transfers, and
                   security, all while you retain full control.
                 </div>
-                <div className="flex items-center gap-7.5">
+                <div className="flex items-center gap-7.5 invisible">
                   <a
                     className=""
                     href=""

--- a/src/app/(frontend)/_components/Home-Sales/Third.tsx
+++ b/src/app/(frontend)/_components/Home-Sales/Third.tsx
@@ -169,7 +169,7 @@ export default function Third() {
       ref={ref}
       className="home-section page-third w-full h-screen-custom flex flex-col justify-center items-center relative overflow-hidden z-[3]"
     >
-      <div className="page-third-container w-full flex flex-auto flex-col justify-between items-center relative">
+      <div className="page-third-container w-full flex flex-auto flex-col justify-between items-center relative px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12 2xl:px-0">
         <div />
         <div className="w-full flex flex-col justify-start items-center gap-12 md:gap-14 lg:gap-16 xl:gap-18 2xl:gap-20 3xl:gap-22 relative z-[1]">
           <div className="px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12 2xl:px-0">
@@ -198,19 +198,12 @@ export default function Third() {
           <div className="w-full">
             <Marquee speed={0.05} direction="left" isInView={isInView} />
           </div>
-          <div className="flex items-center justify-between gap-2 sm:gap-2.5 md:gap-3 lg:gap-3.5 xl:gap-4 px-4 sm:px-6 lg:px-8 xl:px-10 2xl:px-14 3xl:px-16 py-4 md:py-5 lg:py-6 xl:py-7 border-b-[0.6px] border-[#9f9f9f]">
+          <div className="flex justify-center px-4 sm:px-6 lg:px-8 xl:px-10 2xl:px-14 3xl:px-16 py-4 md:py-5 lg:py-6 xl:py-7 border-b-[0.6px] border-[#9f9f9f]">
             <p className="text-xs md:text-sm xl:text-base font-semibold text-white">
               By uniting adaptive AI with resilient decentralized
               infrastructure, we deliver smarter, faster, and truly sovereign
               experiences — built to empower human potential worldwide.
             </p>
-            <Image
-              src="/images/icon-benefit-increase.svg"
-              alt=""
-              width={20}
-              height={20}
-              className="size-4 lg:size-5"
-            />
           </div>
         </div>
       </div>

--- a/src/app/(frontend)/_components/Map/index.tsx
+++ b/src/app/(frontend)/_components/Map/index.tsx
@@ -47,43 +47,41 @@ function CountriesList() {
   return (
     <div className="relative w-full max-w-270 mt-10 border-gradient-rounded line-ray rounded-xl text-base font-semibold text-jet-black">
       <GlowingEdgeCard autoPlayOnHover className="w-full h-full">
-        <div className="flex flex-col w-full bg-eerie-black rounded-xl">
+        <div className="flex flex-col w-full pb-4 bg-eerie-black rounded-xl">
           <div
-            className="py-4.5 -m-0.25 rounded-xl"
+            className="-m-0.25 rounded-xl"
             style={{
               background: "linear-gradient(90deg, #00FFC2 0%, #7DDAFF 100%)",
             }}
           >
-            <div className="flex justify-between px-10">
-              <div className="shrink-0" style={{ width }}>
+            <div className="flex justify-between px-6">
+              <div className="shrink-0 px-3 py-4 border-r-1 border-r-dark-gray" style={{ width }}>
                 Available
               </div>
-              {new Array(columns - 1).fill("").map((_, i) => (
-                <div key={i} className="shrink-0" style={{ width }}>
-                  Waitlist
-                </div>
-              ))}
+              <div className="flex-auto shrink-0 px-3 py-4">
+                Waitlist
+              </div>
             </div>
           </div>
-          <div className="text-white px-10">
+          <div className="text-white px-6">
             {new Array(rows).fill("").map((_, i) => (
               <div
                 key={i}
-                className="flex justify-between py-4 border-b-1 border-b-dark-gray"
+                className="flex justify-between border-b-1 border-b-dark-gray"
               >
-                <div className="shrink-0" style={{ width }}>
+                <div className="shrink-0 px-3 py-2 border-r-1 border-r-dark-gray" style={{ width }}>
                   {availableArr?.[i]}
                 </div>
-                <div className="shrink-0" style={{ width }}>
+                <div className="shrink-0 px-3 py-2" style={{ width }}>
                   {waitlistArr?.[0]?.[i]}
                 </div>
                 {columns >= 3 && (
-                  <div className="shrink-0" style={{ width }}>
+                  <div className="shrink-0 px-3 py-2" style={{ width }}>
                     {waitlistArr?.[1]?.[i]}
                   </div>
                 )}
                 {columns >= 4 && (
-                  <div className="shrink-0" style={{ width }}>
+                  <div className="shrink-0 px-3 py-2" style={{ width }}>
                     {waitlistArr?.[2]?.[i]}
                   </div>
                 )}


### PR DESCRIPTION
1.項目頁面以及銷售頁面的SNS入口先關閉，預期11月初重新開放
2，銷售頁第二畫面的右上動畫日方表示有些卡頓，可能是文件太大了 這個部分看情況需要優化下
3，第三螢幕右下角的圖示日方表示會造成使用者錯覺希望刪除，然後文字也是排在中間比較好
4，第三和第四屏把畫面縮小的時候 尺寸不太對 不過這個應該是響應式的問題 先提出來以免後續漏掉
5，MAP頁面的LIST在目前格式的基礎上希望進行優化，截圖內有幾個，另外是否能把顯示國家的部分的上下空間稍微壓縮一點 目前感覺有些太寬了
6，Roadmap頁面畫面放小後 文字會斷 不過也理解這個是響應式的問題 先提出來
7，專案頁第五畫面的動畫部分 日方感覺這個消失的點有些奇怪 問如果可以的話是否能在螢幕部分拉滿？這個不絕對的需求 看咱們是否能處理